### PR TITLE
Change the view to show the description of items on the item index page

### DIFF
--- a/app/views/merchant/items/index.html.erb
+++ b/app/views/merchant/items/index.html.erb
@@ -15,7 +15,9 @@
     <% else %>
       <%= link_to image_tag("https://t3.ftcdn.net/jpg/02/48/42/64/240_F_248426448_NVKLywWqArG2ADUxDq6QprtIzsF82dMF.jpg"), "items/#{item.id}" %>
     <% end %>  
-    <p> <%= item.description unless @merchant%> </p>
+    <% if @merchant %> 
+      <p> <%= item.description %> </p>
+    <% end %> 
     <p>Price: <%=number_to_currency(item.price) %> </p>
     <p>Inventory: <%= item.inventory %> </p>
     <% if !@merchant %>

--- a/spec/features/users/merchant_add_item_spec.rb
+++ b/spec/features/users/merchant_add_item_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'Merchant add items', type: :feature do
           expect(page).to have_content("Price: $#{new_item.price}")
           expect(page).to have_css("img[src*='#{new_item.image}']")
           expect(page).to have_content("Active")
-          expect(page).to_not have_content(new_item.description)
+          expect(page).to have_content(new_item.description)
           expect(page).to have_content("Inventory: #{new_item.inventory}")
         end
 
@@ -138,7 +138,7 @@ RSpec.describe 'Merchant add items', type: :feature do
           expect(page).to have_content("Price: $#{new_item.price}")
           expect(page).to have_css("img[src*='#{"https://t3.ftcdn.net/jpg/02/48/42/64/240_F_248426448_NVKLywWqArG2ADUxDq6QprtIzsF82dMF.jpg"}']")
           expect(page).to have_content("Active")
-          expect(page).to_not have_content(new_item.description)
+          expect(page).to have_content(new_item.description)
           expect(page).to have_content("Inventory: #{new_item.inventory}")
         end
         

--- a/spec/features/users/merchant_edit_item_spec.rb
+++ b/spec/features/users/merchant_edit_item_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe 'As a merchant employee', type: :feature do
         expect(page).to have_content("Price: $#{price}")
         expect(page).to have_css("img[src*='#{image_url}']")
         expect(page).to have_content('Active')
-        expect(page).to_not have_content(description)
+        expect(page).to have_content(description)
         expect(page).to have_content("Inventory: #{inventory}")
       end
 
@@ -114,7 +114,7 @@ RSpec.describe 'As a merchant employee', type: :feature do
         expect(page).to have_content("Price: $#{price}")
         expect(page).to have_css("img[src*='https://t3.ftcdn.net/jpg/02/48/42/64/240_F_248426448_NVKLywWqArG2ADUxDq6QprtIzsF82dMF.jpg']")
         expect(page).to have_content('Active')
-        expect(page).to_not have_content(description)
+        expect(page).to have_content(description)
         expect(page).to have_content("Inventory: #{inventory}")
       end
     end


### PR DESCRIPTION
- changed a conditional in the `merchant` `items` `index` page 
- changed the tests I had written that did not error out on the missing `description`